### PR TITLE
Ngff table data

### DIFF
--- a/view_kyoda_wormdata.py
+++ b/view_kyoda_wormdata.py
@@ -1,0 +1,88 @@
+import os
+import zarr
+import numpy as np
+from anndata import AnnData
+from anndata._io import read_zarr
+from ome_zarr.io import parse_url
+from ome_zarr.reader import Reader
+import napari
+from napari_ome_zarr._reader import transform
+from napari.types import LayerDataTuple
+
+from ngff_tables_prototype.reader import load_table_to_anndata, get_napari_points_layer_data
+
+
+def check_div(tracks_matrix, n):
+    next = 0
+    for i in range(len(tracks_matrix[n])):
+            if tracks_matrix[n][i] == 1:
+                next += 1
+    return next
+
+def track_obj(tracks_matrix, m, points_coords, tracks, tid):
+    if check_div(tracks_matrix, m) == 1:
+        tracks = np.append(tracks, np.insert(points_coords[m], 0, tid))
+        for i in range(len(tracks_matrix[m])):
+            if tracks_matrix[m][i] == 1:
+                tracks_matrix[m][i] = 2
+                tracks = track_obj(tracks_matrix, i, points_coords, tracks, tid)
+        return tracks
+    else:
+        return tracks
+                
+def _anndata_to_napari_tracks(anndata_obj: AnnData) -> LayerDataTuple:
+    points_coords = anndata_obj.X
+    tracks_matrix = anndata_obj.obsm["tracking"]
+    tracks = np.empty((0, 5))
+    
+    tid = 0
+    for i in range(len(tracks_matrix)):
+        for j in range(len(tracks_matrix[i])):
+            if tracks_matrix[i][j] == 1:
+                tracks = np.append(tracks, np.insert(points_coords[i], 0, tid))
+                tracks = track_obj(tracks_matrix, j, points_coords, tracks, tid)
+                tid += 1
+
+    t = tracks.reshape([tracks.size // 5, 5])
+
+    return t, "", 'tracks'
+
+
+def load_to_napari_layer_bdz(file_path: str):
+    ome_zarr = parse_url(file_path)
+    reader = Reader(ome_zarr)
+    reader_func = transform(reader())
+    layer_data = reader_func(file_path)
+
+    TABLES_DIR = "tables"
+    table_group = zarr.group(store=ome_zarr.store, path=TABLES_DIR)
+    table_attrs = table_group.attrs.asdict()
+    print("table_attrs", table_attrs)
+
+    # assume just one table...
+    table_name = table_attrs["tables"][0]
+    table_path = os.path.join(TABLES_DIR, table_name)
+    print("loading points data from ", table_path)
+
+    # load points points
+    points_layer = get_napari_points_layer_data(file_path, table_path)
+    layer_data.append(points_layer)
+
+    # load tracking info. (added)
+    anndata_obj = load_table_to_anndata(file_path, table_path)
+    layer_data.append(_anndata_to_napari_tracks(anndata_obj))
+    
+    return layer_data
+
+def load_to_napari_viewer_bdz(file_path: str) -> napari.Viewer:
+    layer_data = load_to_napari_layer_bdz(file_path)
+
+    viewer = napari.Viewer()
+
+    for layer in layer_data:
+        viewer._add_layer_from_data(*layer)
+    return viewer
+
+viewer = load_to_napari_viewer_bdz(file_path='wt-N2-081015-01.ome.zarr')
+napari.run()
+

--- a/write_kyoda_wormdata.py
+++ b/write_kyoda_wormdata.py
@@ -1,0 +1,72 @@
+import pandas as pd
+import os
+import glob
+import anndata as ad
+import numpy as np
+from ome_zarr.io import parse_url
+import zarr
+from ngff_tables_prototype.writer import write_table_regions
+
+
+df = pd.read_csv('wt-N2-081015-01.csv', names=('t', 'pid', 'cid', 'x', 'y', 'z', 'name', 'sphericity', 'volume', 'phase'))
+df['entity'] = 'line'
+
+
+print(df.head())
+
+print(df)
+
+
+n_obs, n_vars = 65, 4
+nmp = df[["t", "z", "y", "x"]].values
+Y = nmp
+X1 = Y / np.array([1, 0.5016, 0.1015, 0.1015])
+X2 = X1 * np.array([1, -1, 1, 1])
+X = X2 + np.array([0, 65, 0, 0])
+
+dfa = pd.DataFrame(X, columns=list('tzyx'), index=np.arange(n_obs, dtype=int).astype(str))
+
+# print("X", X)
+
+# print("dfa", dfa)
+# t          z           y           x
+# 0    1.0  39.922648  109.316256  307.414778
+# 1    2.0  39.498206  113.885714  309.511330
+# 2    3.0  39.999203  111.549754  315.685714
+
+obs_raw = df.loc[:,["cid", "entity", "name", "sphericity", "volume"]]
+
+obs_meta = obs_raw.rename(columns={'cid': 'id'})
+
+col = obs_meta.loc[:, 'id']
+col.transpose()
+
+# NB: use int8 to allow viewing in web
+obsp_raw = np.loadtxt('wt-N2-081015-01-track.csv', delimiter=',', dtype=np.int8)
+obsp_meta = pd.DataFrame(obsp_raw, index = col.astype(str), columns = col.astype(str))
+
+# print(obsp_meta)
+# id     1000  2000  3000  4000  5000  6000  7000  8000  9000  10000  ...  46000  46001  47000  47001  48000  48001  49000  49001  50000  50001
+# id                                                                  ...                                                                      
+# 1000      0     1     0     0     0     0     0     0     0      0  ...      0      0      0      0      0      0      0      0      0      0
+# 2000      0     0     1     0     0     0     0     0     0      0  ...      0      0      0      0      0      0      0      0      0      0
+# 3000      0     0     0     1     0     0     0     0     0      0  ...      0      0      0      0      0      0      0      0      0      0
+
+
+adata = ad.AnnData(X = dfa, obs = obs_meta)
+# simple 2D table is suitable for obsm data
+adata.obsm["tracking"] = obsp_raw
+
+# adata.write_zarr('dyn')
+
+store = parse_url("image.zarr", mode="w").store
+root = zarr.group(store=store)
+
+tables_group = root.create_group(name="tables")
+write_table_regions(
+    group=tables_group,
+    adata=adata,
+    region="labels/label_image",
+    region_key=None,
+    instance_key="cell_id"
+)

--- a/write_kyoda_wormdata.py
+++ b/write_kyoda_wormdata.py
@@ -2,6 +2,7 @@ import pandas as pd
 import os
 import glob
 import anndata as ad
+from scipy.sparse import csr_matrix
 import numpy as np
 from ome_zarr.io import parse_url
 import zarr
@@ -57,9 +58,10 @@ adata = ad.AnnData(X = dfa, obs = obs_meta)
 # simple 2D table is suitable for obsm data
 adata.obsm["tracking"] = obsp_raw
 
-# adata.write_zarr('dyn')
+# write as sparse data to obsp
+adata.obsp["tracking"] = csr_matrix(obsp_raw)
 
-store = parse_url("image.zarr", mode="w").store
+store = parse_url("wt-N2-081015-01.ome.zarr", mode="w").store
 root = zarr.group(store=store)
 
 tables_group = root.create_group(name="tables")


### PR DESCRIPTION
This is a python script version of `write_kyoda_wormdata.ipnb`, that uses the latest `ngff_tables_prototype` to write OME-NGFF tables under the `wt-N2-081015-01.ome.zarr` image, according to the spec at https://github.com/ome/ngff/pull/64.

NB: this writes the 'tracking' sparse data both to the `obsm` data as a dense array, and to `obsp` as sparse data.

NB: this required a couple of changes at https://github.com/kevinyamauchi/ome-ngff-tables-prototype/pull/14

It can be viewed with https://github.com/ome/ome-ngff-validator/pull/20 if you serve the data locally... e.g.
https://deploy-preview-20--ome-ngff-validator.netlify.app/?source=http://localhost:8000/bdz/wt-N2-081015-01.ome.zarr

<img width="1028" alt="Screenshot 2023-03-03 at 10 53 08" src="https://user-images.githubusercontent.com/900055/222702401-1dbe25f5-6e85-49dd-b90c-f684b44756f8.png">



That will show the image.zarr, and you'll see a link to the underlying `regions_table`:


