### PR TITLE
Use write_table_points instead of regions

### DIFF
--- a/write_kyoda_wormdata.py
+++ b/write_kyoda_wormdata.py
@@ -6,7 +6,7 @@ from scipy.sparse import csr_matrix
 import numpy as np
 from ome_zarr.io import parse_url
 import zarr
-from ngff_tables_prototype.writer import write_table_regions
+from ngff_tables_prototype.writer import write_table_points
 
 
 df = pd.read_csv('wt-N2-081015-01.csv', names=('t', 'pid', 'cid', 'x', 'y', 'z', 'name', 'sphericity', 'volume', 'phase'))
@@ -55,8 +55,6 @@ obsp_meta = pd.DataFrame(obsp_raw, index = col.astype(str), columns = col.astype
 
 
 adata = ad.AnnData(X = dfa, obs = obs_meta)
-# simple 2D table is suitable for obsm data
-adata.obsm["tracking"] = obsp_raw
 
 # write as sparse data to obsp
 adata.obsp["tracking"] = csr_matrix(obsp_raw)
@@ -65,10 +63,7 @@ store = parse_url("wt-N2-081015-01.ome.zarr", mode="w").store
 root = zarr.group(store=store)
 
 tables_group = root.create_group(name="tables")
-write_table_regions(
+write_table_points(
     group=tables_group,
-    adata=adata,
-    region="labels/label_image",
-    region_key=None,
-    instance_key="cell_id"
+    adata=adata
 )


### PR DESCRIPTION
Hi @kkyoda, I have fixed-up the `write_table_points()` method in:
https://github.com/kevinyamauchi/ome-ngff-tables-prototype/pull/15 
which is what I should be using here, since it generates "points_table" instead of "regions_table".

Updated this script to use that.

I've used the same method so export data from idr0113 and made the data public on s3: see https://github.com/IDR/idr0113-bottes-opcclones/pull/2

It would be great to have some public SSBD sample data with anndata tracks too!
